### PR TITLE
Provide option for canonical hash based urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,8 @@ Use a custom program to open link:
 ```
 let g:gh_open_command = 'open '
 ```
+
+Use [canonical version hash](https://help.github.com/articles/getting-permanent-links-to-files/) for url in place of branch name:
+```
+let g:gh_use_canonical = 1
+```

--- a/plugin/vim-gh-line.vim
+++ b/plugin/vim-gh-line.vim
@@ -46,7 +46,12 @@ func! s:gh_line() range
 
     " Git Commands
     let origin = system(cdDir . "git config --get remote.origin.url" . " | " . sed_cmd)
-    let branch = system(cdDir . "git rev-parse --abbrev-ref HEAD")
+    if exists('g:gh_use_canonical')
+        let branch = system(cdDir . "git rev-parse HEAD")
+    else
+        let branch = system(cdDir . "git rev-parse --abbrev-ref HEAD")
+    endif
+
     let gitRoot = system(cdDir . "git rev-parse --show-toplevel")
 
     " Strip Newlines


### PR DESCRIPTION
Just a suggestion to add an option to use the hash in the url instead of the branch name!

Example url: https://github.com/cfebs/vim-gh-line/blob/b86a83e77f146da2a5cbc50d865f2fecb8a8bc9a/plugin/vim-gh-line.vim#L49
