### PR TITLE
Support Github Enterprise.

### DIFF
--- a/plugin/vim-gh-line.vim
+++ b/plugin/vim-gh-line.vim
@@ -61,7 +61,7 @@ func! s:gh_line() range
 
     " Set Line Number/s
     " Form URL With Line Range
-    if match(origin, 'github.com') >= 0
+    if match(origin, 'github') >= 0
       let blob = "/blob/"
       if a:firstline == a:lastline
           let lineRange = 'L' . lineNum


### PR DESCRIPTION
Most github enterprise will have `github` in the DNS but not under `github.com`.