### PR TITLE
Support GitHub Enterprise installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 vim-gh-line
 =============
 
-A vim plugin that open the link to current line at Github (Also support Bitbucket and self deployed gitlab)
+A Vim plugin that opens a link to the current line on GitHub (and also supports Bitbucket and self-deployed GitHub and GitLab).
 
 ![gh-line](https://cloud.githubusercontent.com/assets/486382/10865375/142cd426-8012-11e5-92f8-44357b7acf9c.gif)
 
@@ -44,7 +44,12 @@ Use [canonical version hash](https://help.github.com/articles/getting-permanent-
 let g:gh_use_canonical = 1
 ```
 
-Use self deployed gitlab:
+Use self-deployed GitHub:
+```
+let g:gh_github_domain = "<your github domain>"
+```
+
+Use self-deployed GitLab:
 ```
 let g:gh_gitlab_domain = "<your gitlab domain>"
 ```

--- a/plugin/vim-gh-line.vim
+++ b/plugin/vim-gh-line.vim
@@ -101,7 +101,7 @@ func! s:Commit(cdDir)
 endfunc
 
 func! s:Github(origin)
-  return match(a:origin, 'github') >= 0
+  return exists('g:gh_github_domain') && match(a:origin, g:gh_github_domain) || match(a:origin, 'github') >= 0
 endfunc
 
 func! s:Bitbucket(origin)


### PR DESCRIPTION
Adds a mechanism to support GitHub Enterprise installations, very
similar to how self-hosted GitLab already works.

Users set their GitHub domain with `g:gh_github_domain`:

```
let g:gh_github_domain = "<your github domain>"
```

From there, the script checks for matching Git origins and uses GitHub's
link format if one is found.