### PR TITLE
Update readme: add mappings for blame and an example for using clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,22 @@ To update the plugin to the latest version, you can run `:BundleUpdate`.
 How to use
 ----------
 
-Default key mapping: `<leader>gh`
+Default key mapping for a blob view: `<leader>gh`
 
-To disable default key mapping:
+Default key mapping for a blame view: `<leader>gb`
+
+To disable default key mappings:
 
 ```
 let g:gh_line_map_default = 0
+let g:gh_line_blame_map_default = 1
 ```
 
-Use your own mapping:
+Use your own mappings:
 
 ```
 let g:gh_line_map = '<leader>gh'
+let g:gh_line_blame_map = '<leader>gb'
 ```
 
 Use a custom program to open link:
@@ -39,12 +43,18 @@ Use a custom program to open link:
 let g:gh_open_command = 'open '
 ```
 
+Copy link to a clipboard instead of opening a browser:
+```
+let g:gh_open_command = 'fn() { echo "$@" | pbcopy; }; fn '
+```
+
 Use [canonical version hash](https://help.github.com/articles/getting-permanent-links-to-files/) for url in place of branch name:
 ```
 let g:gh_use_canonical = 1
 ```
 
-Use self deployed gitlab:
+Use a self deployed gitlab (the value is a matching regex, i.e. you can use
+multiple domains separated with `|`):
 ```
 let g:gh_gitlab_domain = "<your gitlab domain>"
 ```


### PR DESCRIPTION
Git blame support has been added in #9, this PR updates the README.md for that.

I also added a quick example of using a clipboard on macos instead of opening a browser, which I, personally, find more useful.