### PR TITLE
Added the first unit test 

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -x
+
+
+# Start vi in the cleanest possible way and only load the tests and the
+# plugin directory
+vim  -N -U NONE -i NONE -u <(cat << VIMRC
+set rtp+=../
+source ./vim-gh-line_test.vim
+VIMRC) -c 'RunAllTests'
+

--- a/test/vim-gh-line_test.vim
+++ b/test/vim-gh-line_test.vim
@@ -4,6 +4,17 @@ if exists('g:loaded_vim_gt_line_test') || &compatible
 endif
 let g:loaded_vim_gt_line_test = 1
 
+" Print the given string in vim and also outside of vim.
+func! s:persistedPrint(output)
+  echom a:output
+
+  let lines = split(a:output, '\n')
+  let tmp = tempname()
+  call writefile(lines, tmp)
+  execute printf('silent !%s %s 1>&2', 'cat', tmp)
+  call delete(tmp)
+endfunction
+
 " Given the scriptName return the SID for the current runtime of vim.
 " Lists all sourced scripts, finds the scrip line that mathes the given
 " scriptName. Expects only one match. Then parses the line describing the
@@ -14,7 +25,6 @@ func! s:getScriptID(scriptName)
 
     let l:matchingLine = ''
     for line in l:allScripts
-        echom 'Printing line ' . line
         if line =~ a:scriptName
             " First time seeing a matching script.
             if l:matchingLine == ''
@@ -32,11 +42,33 @@ func! s:getScriptID(scriptName)
     " The matching line looks like this:
     " 20: ~/src/ruanyl/vim-gh-line/plugin/vim-gh-line.vim
     " extract the first number before : and return it as the scriptID
+    let l:matchingList = split(l:matchingLine)
+    if len(l:matchingList) != 2
+        throw 'Unexlected line in scriptnames: ' . l:matchingLine
+    endif
+
+    let l:firstEntry = l:matchingList[0]
+    let l:rv =  substitute(l:firstEntry, ':', '', '')
+    return l:rv
 endfunction
 
 
-" TODO: Add an Assert function that prints an error message and exists with
-" error (cq)
+func! s:callWithSID(sid,funcName,...)
+    let l:FuncRef = function('<SNR>' . a:sid . '_' . a:funcName)
+    let l:rv = call(l:FuncRef, a:000)
+    return l:rv
+endfunc
+
+func! s:testGithub(sid)
+    call s:persistedPrint('Calling testGithub')
+
+    let l:act = s:callWithSID(a:sid, 'Github', 'https://github.com/ruanyl/vim-gh-line.git')
+    call assert_equal(l:act, 1, 'Github can parse github remote correctly')
+
+    let l:act = s:callWithSID(a:sid, 'Github', 'https://otherDomain.com/ruanyl/vim-gh-line.git')
+    call assert_equal(l:act, 0, 'Github detect non-github domain.')
+
+endfunction
 
 
 " runAllTests is the entrance function of this test file. It is called from the
@@ -44,19 +76,17 @@ endfunction
 " called in it. Once you add a new test function, make sure you modify
 " runAllTest too.
 func! s:runAllTests()
-    echom "Calling runAllTest"
+    call s:persistedPrint('Calling runAllTest')
 
-    " let l:scriptID = s:getScriptID("vim-gh-line.vim")
-    let l:scriptID = s:getScriptID("vim-gh-line.vim")
+    let l:scriptName = 'vim-gh-line.vim'
+    let l:scriptID = s:getScriptID(l:scriptName)
+    call s:persistedPrint('SID for script: ' . l:scriptName . ' is: ' . l:scriptID)
 
-endfunction
 
-func! s:printStderr(output)
-  let lines = split(a:output, '\n')
-  let tmp = tempname()
-  call writefile(lines, tmp)
-  execute printf('silent !%s %s 1>&2', 'cat', tmp)
-  call delete(tmp)
+    " Add all test functions here.
+    call s:testGithub(l:scriptID)
+
+
 endfunction
 
 func! s:tryRunAllTests()
@@ -64,12 +94,12 @@ func! s:tryRunAllTests()
         call s:runAllTests()
     catch
         let l:error = 'Test error: ' . v:exception . ' (in ' . v:throwpoint . ')'
-        call s:printStderr(l:error)
-        echom 'TESTS FAILED'
+        call s:persistedPrint(l:error)
+        call s:persistedPrint('TESTS FAILED')
         " quit with error
         cq
     finally
-        echom 'TESTS PASSED'
+        call s:persistedPrint('TESTS PASSED')
         " quit with sucess
         qall
     endtry

--- a/test/vim-gh-line_test.vim
+++ b/test/vim-gh-line_test.vim
@@ -1,0 +1,79 @@
+
+if exists('g:loaded_vim_gt_line_test') || &compatible
+  finish
+endif
+let g:loaded_vim_gt_line_test = 1
+
+" Given the scriptName return the SID for the current runtime of vim.
+" Lists all sourced scripts, finds the scrip line that mathes the given
+" scriptName. Expects only one match. Then parses the line describing the
+" given scriptName
+func! s:getScriptID(scriptName)
+
+    let l:allScripts = split(execute('scriptnames'), '\n')
+
+    let l:matchingLine = ''
+    for line in l:allScripts
+        echom 'Printing line ' . line
+        if line =~ a:scriptName
+            " First time seeing a matching script.
+            if l:matchingLine == ''
+                let l:matchingLine = line
+            else
+                " Multiple matches of the scriptName. Unexpected
+                throw 'Found ' . a:scriptName . ' multiple times in sourced scripts.'
+            endif
+        endif
+    endfor
+    if l:matchingLine == ''
+        throw  'Could not find ' . a:scriptName . ' in sourced scripts'
+    endif
+
+    " The matching line looks like this:
+    " 20: ~/src/ruanyl/vim-gh-line/plugin/vim-gh-line.vim
+    " extract the first number before : and return it as the scriptID
+endfunction
+
+
+" TODO: Add an Assert function that prints an error message and exists with
+" error (cq)
+
+
+" runAllTests is the entrance function of this test file. It is called from the
+" RunAllTests command. Right now all other test functions need to be explicitly
+" called in it. Once you add a new test function, make sure you modify
+" runAllTest too.
+func! s:runAllTests()
+    echom "Calling runAllTest"
+
+    " let l:scriptID = s:getScriptID("vim-gh-line.vim")
+    let l:scriptID = s:getScriptID("vim-gh-line.vim")
+
+endfunction
+
+func! s:printStderr(output)
+  let lines = split(a:output, '\n')
+  let tmp = tempname()
+  call writefile(lines, tmp)
+  execute printf('silent !%s %s 1>&2', 'cat', tmp)
+  call delete(tmp)
+endfunction
+
+func! s:tryRunAllTests()
+    try
+        call s:runAllTests()
+    catch
+        let l:error = 'Test error: ' . v:exception . ' (in ' . v:throwpoint . ')'
+        call s:printStderr(l:error)
+        echom 'TESTS FAILED'
+        " quit with error
+        cq
+    finally
+        echom 'TESTS PASSED'
+        " quit with sucess
+        qall
+    endtry
+endfunction
+
+command!  RunAllTests call s:tryRunAllTests()
+


### PR DESCRIPTION
Hi @ruanyl , 
while I was working on adding the cgit support, I felt the dire need to add some test coverage to the plugin. With expanding support for github, gitlab, bitbucket and cgit, the different ways the plugin can fail increases rapidly. It felt impossible to add cgit support and not break something else. 

So here we go. This PR is my take to adding unit tests. Right now the only test is for `s:Github` function. I added that as an example for how tests should look like. We can discuss further. If this looks reasonable to you I will add more test coverage in my cgit related PR. 

The approach  looks similar to what the actual vim upstream does. Take a look at their unit test runner [here](https://github.com/vim/vim/blob/8617b401599451187fa0c0561a84944978536a90/src/testdir/runtest.vim#L330) and an example test file [here](https://github.com/vim/vim/blob/8617b401599451187fa0c0561a84944978536a90/src/testdir/test_mapping.vim). 

This is all vim-native no other plugin or dependency is necessary. I have tested it in maxOS ElCapitan 10.11.6 and vim 8.1. But it should work in vim7x too. (I think)

One quirk in this PR is the implementation for testing script-local functions (s:funcName). Since most of the functions are in a "plugin" directory and they are defined as script local, we need to do some extra work in the test file to call them. You can read [here](https://vi.stackexchange.com/q/17866/13792) for more about it. 

references  #18 
Someone else needs to add the travisci or circleci config so that the unit tests are executed pre merge. 
