### PR TITLE
Fix `ssh://git@github.com/<repo>` remotes

### DIFF
--- a/plugin/vim-gh-line.vim
+++ b/plugin/vim-gh-line.vim
@@ -256,10 +256,12 @@ endfun
 func! s:TransformSSHToHTTPS(input)
     " If the remote is using ssh protocol, we need to turn a git remote like this:
     " `git@github.com:<suffix>`
+    " or
+    " `ssh://git@github.com/<suffix>`
     " To a url like this:
     " `https://github.com/<suffix>`
     let l:rv = a:input
-    let l:sed_cmd = "sed 's\/^[^@:]*@\\([^:]*\\):\/https:\\\/\\\/\\1\\\/\/;'"
+    let l:sed_cmd = "sed 's\/^[^@]*@\\([^:\\\/]*\\)[:\\\/]\/https:\\\/\\\/\\1\\\/\/;'"
     let l:rv = system("echo " . l:rv . " | " . l:sed_cmd)
     return l:rv
 endfun

--- a/test/vim-gh-line_test.vim
+++ b/test/vim-gh-line_test.vim
@@ -109,7 +109,12 @@ func! s:testGithubUrl(sid)
     let l:act = s:callWithSID(a:sid, 'GithubUrl',
         \ 'git@github.com:ruanyl/vim-gh-line.git')
     call assert_equal('https://github.com/ruanyl/vim-gh-line', l:act,
-        \ 'GithubUrl unexpected result with ssh protocol')
+        \ 'GithubUrl unexpected result with ssh protocol (scp style)')
+
+    let l:act = s:callWithSID(a:sid, 'GithubUrl',
+        \ 'ssh://git@github.com/ruanyl/vim-gh-line.git')
+    call assert_equal('https://github.com/ruanyl/vim-gh-line', l:act,
+        \ 'GithubUrl unexpected result with ssh protocol (ssh:// style)')
 endfunction
 
 func! s:testBitBucketUrl(sid)


### PR DESCRIPTION
I tend to remap remotes from `https://` to `ssh://` so I can use SSH keys. Not sure why GitHub prefers the SCP-style format.