### PR TITLE
Support for googlesource.com links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
  [![Build Status](https://travis-ci.org/ruanyl/vim-gh-line.svg?branch=master)](https://travis-ci.org/ruanyl/vim-gh-line)
 
-A Vim plugin that opens a link to the current line on GitHub (and also supports Bitbucket and self-deployed GitHub and GitLab).
+A Vim plugin that opens a link to the current line on GitHub (and also supports Bitbucket, self-deployed GitHub, Googlesource and GitLab).
 
 ![gh-line](https://cloud.githubusercontent.com/assets/486382/10865375/142cd426-8012-11e5-92f8-44357b7acf9c.gif)
 

--- a/plugin/vim-gh-line.vim
+++ b/plugin/vim-gh-line.vim
@@ -245,6 +245,7 @@ endfunc
 
 func! s:GoogleSrc(remote_url)
   return match(a:remote_url, 'googlesource.com') >= 0
+endfunc
 
 func! s:Bitbucket(remote_url)
   return match(a:remote_url, 'bitbucket.org') >= 0

--- a/plugin/vim-gh-line.vim
+++ b/plugin/vim-gh-line.vim
@@ -114,6 +114,8 @@ func! s:gh_line(action, force_interactive) range
     if s:Github(remote_url)
       let lineRange = s:GithubLineLange(a:firstline, a:lastline, lineNum)
       let url = s:GithubUrl(remote_url) . action . commit . relative . '#' . lineRange
+    elseif s:GoogleSrc(remote_url)
+      let url = s:GoogleSrcUrl(remote_url) . '/+/' . commit . relative . '#' . lineNum
     elseif s:Bitbucket(remote_url)
       let lineRange = s:BitbucketLineRange(a:firstline, a:lastline, lineNum)
       let url = s:BitBucketUrl(remote_url) . action . commit . relative . '#' . lineRange
@@ -241,6 +243,10 @@ func! s:Github(remote_url)
   return exists('g:gh_github_domain') && match(a:remote_url, g:gh_github_domain) >= 0 || match(a:remote_url, 'github') >= 0
 endfunc
 
+func! s:GoogleSrc(remote_url)
+  return match(a:remote_url, 'googlesource.com') >= 0
+endfunc
+
 func! s:Bitbucket(remote_url)
   return match(a:remote_url, 'bitbucket.org') >= 0
 endfunc
@@ -329,6 +335,14 @@ func! s:EscapedRemoteRef(remote_ref)
 endfun
 
 func! s:GithubUrl(remote_url)
+  let l:rv = s:TransformSSHToHTTPS(a:remote_url)
+  let l:rv = s:StripNL(l:rv)
+  let l:rv = s:StripSuffix(l:rv, '.git')
+
+  return l:rv
+endfunc
+
+func! s:GoogleSrcUrl(remote_url)
   let l:rv = s:TransformSSHToHTTPS(a:remote_url)
   let l:rv = s:StripNL(l:rv)
   let l:rv = s:StripSuffix(l:rv, '.git')


### PR DESCRIPTION
Hello, 

   I love this plugin, really helpful! However, while I was working on a googlesource.com project, I noticed that there wasn't support for it (i.e: https://go.googlesource.com/ , https://chromium.googlesource.com/ , https://android.googlesource.com/) So I tried to make an implementation of it. Googlesource.com is where Google hosts many opensource projects which is based off of Gtiles. Gtiles is a simple git repository browser which is the which is the reason that there is no range option, you can only highlight one line.