### PR TITLE
Use upstream ref if possible

### DIFF
--- a/plugin/vim-gh-line.vim
+++ b/plugin/vim-gh-line.vim
@@ -231,11 +231,31 @@ func! s:Action(remote_url, action)
   endif
 endfunc
 
-func! s:Commit(cdDir)
-  if exists('g:gh_use_canonical') && g:gh_use_canonical > 0
-    return system(a:cdDir . 'git rev-parse HEAD')
+func! s:BranchName(cdDir, ref)
+  return trim(system(a:cdDir . 'git rev-parse --abbrev-ref ' . a:ref))
+endfunc
+
+func! s:CommitRef(cdDir)
+  let l:upstreamBranch = system(a:cdDir . 'git rev-parse --abbrev-ref --symbolic-full-name @{u}')
+  if v:shell_error == 0
+    return l:upstreamBranch
   else
-    return system(a:cdDir . 'git rev-parse --abbrev-ref HEAD')
+    let l:currentBranch = s:BranchName(a:cdDir, 'HEAD')
+    let l:branch = input('Please provide a remote branch (defaults to ' . l:currentBranch . '): ')
+    if len(l:branch) == 0
+      return l:currentBranch
+    endif
+
+    return l:branch
+  endif
+endfunc
+
+func! s:Commit(cdDir)
+  let l:ref = s:CommitRef(a:cdDir)
+  if exists('g:gh_use_canonical') && g:gh_use_canonical > 0
+    return system(a:cdDir . 'git rev-parse ' . l:ref)
+  else
+    return s:BranchName(l:ref)
   endif
 endfunc
 

--- a/test/vim-gh-line_test.vim
+++ b/test/vim-gh-line_test.vim
@@ -93,7 +93,7 @@ func! s:testCommit(sid)
 
     let g:gh_use_canonical = 0
     let l:act = s:callWithSID(a:sid, 'Commit', l:cdDir)
-    call assert_match(l:branch, l:act,
+    call assert_equal(l:branch, l:act,
         \ 'Expected to find branch name in the Commit output ')
     unlet g:gh_use_canonical
 endfunction


### PR DESCRIPTION
When the current branch tracks an upstream branch, generate a link to
that upstream branch (or SHA) rather than using the local one, since it
may not exist upstream.

In the case that the local branch has no upstream, prompt the user for
the branch name to generate a link for.

Partly addresses https://github.com/ruanyl/vim-gh-line/issues/10.

Co-authored-by: souldzin <souldzin@souldzin.com>