### PR TITLE
Add support for SourceHut (git.sr.ht) repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
  [![Build Status](https://travis-ci.org/ruanyl/vim-gh-line.svg?branch=master)](https://travis-ci.org/ruanyl/vim-gh-line)
 
-A Vim plugin that opens a link to the current line on GitHub (and also supports Bitbucket, self-deployed GitHub, Googlesource and GitLab).
+A Vim plugin that opens a link to the current line on GitHub (and also supports Bitbucket, self-deployed GitHub, Googlesource, GitLab, and SourceHut).
 
 ![gh-line](https://cloud.githubusercontent.com/assets/486382/10865375/142cd426-8012-11e5-92f8-44357b7acf9c.gif)
 
@@ -90,6 +90,13 @@ let g:gh_gitlab_domain = "<your gitlab domain>"
 ##### Use self deployed gitlab only with http:
 ```
 let g:gh_gitlab_only_http = 1
+```
+
+#### Use self-deployed SourceHut:
+Use a self deployed SourceHut (the value is a matching regex, i.e. you can use
+multiple domains separated with `|`):
+```
+let g:gh_srht_domain = "<your sourcehut domain>"
 ```
 
 #### Use a git remote with Cgit front end:

--- a/test/vim-gh-line_test.vim
+++ b/test/vim-gh-line_test.vim
@@ -145,6 +145,19 @@ func! s:testGitLabUrl(sid)
         \ 'GitLabUrl unexpected result with ssh protocol')
 endfunction
 
+func! s:testSrHtUrl(sid)
+    call s:persistedPrint('Calling testSrHtUrl')
+
+    let l:act = s:callWithSID(a:sid, 'SrHtUrl',
+        \ 'https://git.sr.ht/~sircmpwn/meta.sr.ht')
+    call assert_equal('https://git.sr.ht/~sircmpwn/meta.sr.ht', l:act,
+        \ 'SrHtUrl unexpected result with https protocol')
+
+    let l:act = s:callWithSID(a:sid, 'SrHtUrl',
+        \ 'git@git.sr.ht:~sircmpwn/meta.sr.ht')
+    call assert_equal('https://git.sr.ht/~sircmpwn/meta.sr.ht', l:act,
+        \ 'SrHtUrl unexpected result with ssh protocol')
+endfunction
 
 func! s:testGhCgitUrlPatternSubUsage(sid)
     " testGhCgitUrlPatternSubUsage verifies code that uses g:gh_cgit_url_pattern_sub
@@ -270,6 +283,7 @@ func! s:runAllTests()
     call s:testGithubUrl(l:scriptID)
     call s:testBitBucketUrl(l:scriptID)
     call s:testGitLabUrl(l:scriptID)
+    call s:testSrHtUrl(l:scriptID)
 
     call s:testGhCgitUrlPatternSubUsage(l:scriptID)
     call s:testGhCgitUrlPatternSubUsageErrors(l:scriptID)


### PR DESCRIPTION
This add support for git repos hosted on the "official" SourceHut
instance: https://git.sr.ht. All actions are supported.