### PR TITLE
feat: use short commit instead of full sha

### DIFF
--- a/plugin/vim-gh-line.vim
+++ b/plugin/vim-gh-line.vim
@@ -249,9 +249,9 @@ endfunc
 
 func! s:Commit(cdDir)
   if exists('g:gh_use_canonical') && g:gh_use_canonical > 0
-    return system(a:cdDir . 'git rev-parse HEAD')
+    return system(a:cdDir . 'git rev-parse --short HEAD')
   else
-    return system(a:cdDir . 'git rev-parse --abbrev-ref HEAD')
+    return system(a:cdDir . 'git rev-parse --abbrev-ref --short HEAD')
   endif
 endfunc
 

--- a/test/vim-gh-line_test.vim
+++ b/test/vim-gh-line_test.vim
@@ -89,7 +89,7 @@ func! s:testCommit(sid)
     let l:fileDir = resolve(expand("%:p:h"))
     let l:cdDir = "cd '" . fileDir . "'; "
 
-    let l:branch = system(l:cdDir . 'git rev-parse --abbrev-ref HEAD')
+    let l:branch = system(l:cdDir . 'git rev-parse --abbrev-ref --short HEAD')
 
     let g:gh_use_canonical = 0
     let l:act = s:callWithSID(a:sid, 'Commit', l:cdDir)
@@ -384,4 +384,3 @@ func! s:tryRunAllTests()
 endfunction
 
 command!  RunAllTests call s:tryRunAllTests()
-


### PR DESCRIPTION
This will reduce the length of the url, eg:

```
$ git rev-parse HEAD
6e64a14a6fdf23442c15d3c0a39501d013187f61

$ git rev-parse --short HEAD
6e64a14a6
```